### PR TITLE
Options to pass hasher

### DIFF
--- a/boc/boc.go
+++ b/boc/boc.go
@@ -301,11 +301,11 @@ func SerializeBoc(cell *Cell, idx bool, hasCrc32 bool, cacheBits bool, flags uin
 	return bag.SerializeBoc([]*Cell{cell}, mode(idx, hasCrc32, cacheBits))
 }
 
-// bagOfCells serializes cells to a boc.
+// BagOfCells serializes cells to a boc.
 //
 // the serialization algorithms is a golang version of
 // https://github.com/ton-blockchain/ton/blob/master/crypto/vm/boc.cpp#
-type bagOfCells struct {
+type BagOfCells struct {
 	hasher *Hasher
 }
 
@@ -321,7 +321,7 @@ func BagWithHasher(hasher *Hasher) BagOption {
 	}
 }
 
-func NewBagOfCells(opts ...BagOption) *bagOfCells {
+func NewBagOfCells(opts ...BagOption) *BagOfCells {
 	options := &BagOptions{}
 	for _, o := range opts {
 		o(options)
@@ -329,7 +329,7 @@ func NewBagOfCells(opts ...BagOption) *bagOfCells {
 	if options.hasher == nil {
 		options.hasher = NewHasher()
 	}
-	return &bagOfCells{
+	return &BagOfCells{
 		hasher: options.hasher,
 	}
 }
@@ -374,7 +374,7 @@ func (m SerializationMode) withCacheBits() bool {
 // SerializeBoc converts the given list of root cells to a byte representation.
 // If you are not sure about mode, use mode = 0.
 // 0 works well for the most use-cases.
-func (boc *bagOfCells) SerializeBoc(rootCells []*Cell, mode SerializationMode) ([]byte, error) {
+func (boc *BagOfCells) SerializeBoc(rootCells []*Cell, mode SerializationMode) ([]byte, error) {
 	//	serialized_boc#672fb0ac has_idx:(## 1) has_crc32c:(## 1)
 	//	has_cache_bits:(## 1) flags:(## 2) { flags = 0 }
 	//	size:(## 3) { size <= 4 }
@@ -495,7 +495,7 @@ func (boc *bagOfCells) SerializeBoc(rootCells []*Cell, mode SerializationMode) (
 	return resBytes, nil
 }
 
-func (boc *bagOfCells) importRoots(rootCells []*Cell) ([]*rootInfo, []*cellInfo, error) {
+func (boc *BagOfCells) importRoots(rootCells []*Cell) ([]*rootInfo, []*cellInfo, error) {
 	roots := make([]*rootInfo, 0, len(rootCells))
 	state := &orderState{
 		cells: map[string]int{},
@@ -515,7 +515,7 @@ func (boc *bagOfCells) importRoots(rootCells []*Cell) ([]*rootInfo, []*cellInfo,
 	return roots, cellInfos, nil
 }
 
-func (boc *bagOfCells) importCell(state *orderState, cell *Cell, depth int) (int, error) {
+func (boc *BagOfCells) importCell(state *orderState, cell *Cell, depth int) (int, error) {
 	if depth > maxDepth {
 		return 0, ErrDepthIsTooBig
 	}
@@ -603,7 +603,7 @@ const (
 	allocate
 )
 
-func (boc *bagOfCells) revisit(state, newState *orderState, cellIndex int, force force) int {
+func (boc *BagOfCells) revisit(state, newState *orderState, cellIndex int, force force) int {
 	dci := state.cellList[cellIndex]
 	if dci.newIndex >= 0 {
 		return dci.newIndex
@@ -647,7 +647,7 @@ func (boc *bagOfCells) revisit(state, newState *orderState, cellIndex int, force
 	return dci.newIndex
 
 }
-func (boc *bagOfCells) reorderCells(roots []*rootInfo, state *orderState) []*cellInfo {
+func (boc *BagOfCells) reorderCells(roots []*rootInfo, state *orderState) []*cellInfo {
 	for i := len(state.cellList) - 1; i >= 0; i-- {
 		dci := state.cellList[i]
 		c := dci.refsNumber

--- a/boc/boc_test.go
+++ b/boc/boc_test.go
@@ -18,8 +18,8 @@ func TestBigCell(t *testing.T) {
 		t.Fail()
 		return
 	}
-	bag := newBagOfCells()
-	x, err := bag.serializeBoc([]*Cell{cells[0]}, false, true, false, 0)
+	bag := NewBagOfCells()
+	x, err := bag.SerializeBoc([]*Cell{cells[0]}, false, true, false, 0)
 	if err != nil {
 		fmt.Println(err)
 		t.Fail()
@@ -374,10 +374,10 @@ func Test_bagOfCells_serializeBoc(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to deserialize boc: %v", err)
 			}
-			bag := newBagOfCells()
-			bs, err := bag.serializeBoc(cells, tt.hasIndex, tt.hasCrc, tt.hasCacheBits, 0)
+			bag := NewBagOfCells()
+			bs, err := bag.SerializeBoc(cells, tt.hasIndex, tt.hasCrc, tt.hasCacheBits, 0)
 			if err != nil {
-				t.Fatalf("serializeBoc() failed: %v", err)
+				t.Fatalf("SerializeBoc() failed: %v", err)
 			}
 			if tt.hexBoc != hex.EncodeToString(bs) {
 				t.Fatalf("serializedBoc differs from hexBoc")

--- a/boc/boc_test.go
+++ b/boc/boc_test.go
@@ -19,7 +19,7 @@ func TestBigCell(t *testing.T) {
 		return
 	}
 	bag := NewBagOfCells()
-	x, err := bag.SerializeBoc([]*Cell{cells[0]}, false, true, false, 0)
+	x, err := bag.SerializeBoc([]*Cell{cells[0]}, 0)
 	if err != nil {
 		fmt.Println(err)
 		t.Fail()
@@ -329,13 +329,11 @@ func BenchmarkDeserializeBoc(b *testing.B) {
 
 func Test_bagOfCells_serializeBoc(t *testing.T) {
 	tests := []struct {
-		name         string
-		hexBoc       string
-		hasIndex     bool
-		hasCrc       bool
-		hasCacheBits bool
-		want         []byte
-		wantErr      bool
+		name    string
+		hexBoc  string
+		mode    SerializationMode
+		want    []byte
+		wantErr bool
 	}{
 		{
 			name:   "complex boc",
@@ -346,22 +344,19 @@ func Test_bagOfCells_serializeBoc(t *testing.T) {
 			hexBoc: multirootBocWithText,
 		},
 		{
-			name:     "with index",
-			hexBoc:   "b5ee9c7281010401003d0015172b3d03200000000000000001000000000000000201010200000220000000000000000300000000000000040303002000000000000000010000000000000002",
-			hasIndex: true,
+			name:   "with index",
+			hexBoc: "b5ee9c7281010401003d0015172b3d03200000000000000001000000000000000201010200000220000000000000000300000000000000040303002000000000000000010000000000000002",
+			mode:   WithIndex,
 		},
 		{
-			name:     "with index, with crc",
-			hexBoc:   "b5ee9c72c1010401003d0015172b3d032000000000000000010000000000000002010102000002200000000000000003000000000000000403030020000000000000000100000000000000029524008b",
-			hasIndex: true,
-			hasCrc:   true,
+			name:   "with index, with crc",
+			hexBoc: "b5ee9c72c1010401003d0015172b3d032000000000000000010000000000000002010102000002200000000000000003000000000000000403030020000000000000000100000000000000029524008b",
+			mode:   WithIndex | WithCRC32C,
 		},
 		{
-			name:         "with index, with crc, with cache bits",
-			hexBoc:       "b5ee9c72e1010401003d002a2f567b03200000000000000001000000000000000201010200000220000000000000000300000000000000040303002000000000000000010000000000000002b64a27ad",
-			hasIndex:     true,
-			hasCrc:       true,
-			hasCacheBits: true,
+			name:   "with index, with crc, with cache bits",
+			hexBoc: "b5ee9c72e1010401003d002a2f567b03200000000000000001000000000000000201010200000220000000000000000300000000000000040303002000000000000000010000000000000002b64a27ad",
+			mode:   WithIndex | WithCRC32C | WithCacheBits,
 		},
 	}
 	for _, tt := range tests {
@@ -375,7 +370,7 @@ func Test_bagOfCells_serializeBoc(t *testing.T) {
 				t.Fatalf("failed to deserialize boc: %v", err)
 			}
 			bag := NewBagOfCells()
-			bs, err := bag.SerializeBoc(cells, tt.hasIndex, tt.hasCrc, tt.hasCacheBits, 0)
+			bs, err := bag.SerializeBoc(cells, tt.mode)
 			if err != nil {
 				t.Fatalf("SerializeBoc() failed: %v", err)
 			}

--- a/boc/cell.go
+++ b/boc/cell.go
@@ -107,7 +107,7 @@ func (c *Cell) hash(cache map[*Cell]*immutableCell) ([]byte, error) {
 
 func (c *Cell) ToBoc() ([]byte, error) {
 	bag := NewBagOfCells()
-	return bag.SerializeBoc([]*Cell{c}, false, false, false, 0)
+	return bag.SerializeBoc([]*Cell{c}, 0)
 }
 
 func (c *Cell) ToBocString() (string, error) {
@@ -120,7 +120,7 @@ func (c *Cell) ToBocBase64() (string, error) {
 
 func (c *Cell) ToBocCustom(idx bool, hasCrc32 bool, cacheBits bool, flags uint) ([]byte, error) {
 	bag := NewBagOfCells()
-	return bag.SerializeBoc([]*Cell{c}, idx, hasCrc32, cacheBits, 0)
+	return bag.SerializeBoc([]*Cell{c}, mode(idx, hasCrc32, cacheBits))
 }
 
 func (c *Cell) ToBocStringCustom(idx bool, hasCrc32 bool, cacheBits bool, flags uint) (string, error) {

--- a/boc/cell.go
+++ b/boc/cell.go
@@ -106,8 +106,8 @@ func (c *Cell) hash(cache map[*Cell]*immutableCell) ([]byte, error) {
 }
 
 func (c *Cell) ToBoc() ([]byte, error) {
-	bag := newBagOfCells()
-	return bag.serializeBoc([]*Cell{c}, false, false, false, 0)
+	bag := NewBagOfCells()
+	return bag.SerializeBoc([]*Cell{c}, false, false, false, 0)
 }
 
 func (c *Cell) ToBocString() (string, error) {
@@ -119,8 +119,8 @@ func (c *Cell) ToBocBase64() (string, error) {
 }
 
 func (c *Cell) ToBocCustom(idx bool, hasCrc32 bool, cacheBits bool, flags uint) ([]byte, error) {
-	bag := newBagOfCells()
-	return bag.serializeBoc([]*Cell{c}, idx, hasCrc32, cacheBits, 0)
+	bag := NewBagOfCells()
+	return bag.SerializeBoc([]*Cell{c}, idx, hasCrc32, cacheBits, 0)
 }
 
 func (c *Cell) ToBocStringCustom(idx bool, hasCrc32 bool, cacheBits bool, flags uint) (string, error) {

--- a/tlb/decoder.go
+++ b/tlb/decoder.go
@@ -24,6 +24,12 @@ func (dec *Decoder) Unmarshal(c *boc.Cell, o any) error {
 	return decode(c, "", reflect.ValueOf(o), dec)
 }
 
+// Hasher returns an instance of boc.Hasher that has been used by this decoder
+// to unmarshal TL-B data.
+func (dec *Decoder) Hasher() *boc.Hasher {
+	return dec.hasher
+}
+
 // UnmarshalerTLB contains method UnmarshalTLB that must be implemented by a struct
 // if it provides specific unmarshalling code.
 type UnmarshalerTLB interface {

--- a/wallet/mock.go
+++ b/wallet/mock.go
@@ -2,7 +2,9 @@ package wallet
 
 import (
 	"context"
+
 	"github.com/tonkeeper/tongo"
+	"github.com/tonkeeper/tongo/liteapi"
 	"github.com/tonkeeper/tongo/tlb"
 )
 
@@ -39,7 +41,7 @@ func (b *SimpleMockBlockchain) SendMessage(ctx context.Context, payload []byte) 
 	return 0, nil
 }
 
-func (b *SimpleMockBlockchain) GetAccountState(ctx context.Context, accountID tongo.AccountID) (tlb.ShardAccount, error) {
+func (b *SimpleMockBlockchain) GetAccountState(ctx context.Context, accountID tongo.AccountID, opts ...liteapi.MethodOption) (tlb.ShardAccount, error) {
 	return tlb.ShardAccount{
 		Account: tlb.Account{
 			SumType: "Account",

--- a/wallet/models.go
+++ b/wallet/models.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/tonkeeper/tongo"
 	"github.com/tonkeeper/tongo/boc"
+	"github.com/tonkeeper/tongo/liteapi"
 	"github.com/tonkeeper/tongo/tlb"
 )
 
@@ -57,7 +58,7 @@ var codes = map[Version]string{
 type blockchain interface {
 	GetSeqno(ctx context.Context, account tongo.AccountID) (uint32, error)
 	SendMessage(ctx context.Context, payload []byte) (uint32, error)
-	GetAccountState(ctx context.Context, accountID tongo.AccountID) (tlb.ShardAccount, error)
+	GetAccountState(ctx context.Context, accountID tongo.AccountID, opts ...liteapi.MethodOption) (tlb.ShardAccount, error)
 }
 
 func GetCodeByVer(ver Version) *boc.Cell {


### PR DESCRIPTION
So the idea is to use the same Hasher instance to do tlb.Unmarshal() and SerializeBoc(). 
The following pseudo code demonstrates the idea:
```golang
client, _ := liteapi.NewClient()
// this decoder is used to do tlb.Unmarshal()
// and its internal hasher will hashes for some block cells

decoder := tlb.NewDecoder()
block, _ = client.GetBlock(..., liteapi.WithDecoder())

// boc serialization calculates hashes to come up with the proper order of cells.
// providing a hasher with hashes should definitely speed up serialization
hasher := decoder.Hasher()    
bag := boc.NewBagOfCells(boc.BagWithHasher(hasher))

for _, tx := range block.Transactions() {
      // convert tx to a cell
      txBoc, _ := bag.SerializeBoc(txCell)
}

```