### PR TITLE
Change behavior of liteapi.Client

### DIFF
--- a/liteapi/client_test.go
+++ b/liteapi/client_test.go
@@ -189,17 +189,13 @@ func TestLookupBlock(t *testing.T) {
 }
 
 func TestGetOneTransaction(t *testing.T) {
-
 	tongoClient, err := NewClientWithDefaultMainnet()
 	if err != nil {
 		log.Fatalf("Unable to create tongo client: %v", err)
 	}
 	ctx := context.Background()
-	lastBlockID, err := tongoClient.getlastBlock(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	shards, err := tongoClient.GetAllShardsInfo(ctx, lastBlockID.ToBlockIdExt())
+	info, err := tongoClient.GetMasterchainInfo(ctx)
+	shards, err := tongoClient.GetAllShardsInfo(ctx, info.Last.ToBlockIdExt())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/liteapi/pool/connection.go
+++ b/liteapi/pool/connection.go
@@ -5,18 +5,30 @@ import (
 	"sync"
 	"time"
 
+	"github.com/tonkeeper/tongo"
 	"github.com/tonkeeper/tongo/liteclient"
 )
 
 type connection struct {
-	client      *liteclient.Client
-	mu          sync.RWMutex
-	masterSeqno uint32
+	id     int
+	client *liteclient.Client
+
+	// masterHeadUpdatedCh is used to send a notification when a known master head is changed.
+	masterHeadUpdatedCh chan masterHeadUpdated
+
+	mu sync.RWMutex
+	// masterHead is the latest known masterchain head.
+	masterHead tongo.BlockIDExt
+}
+
+type masterHeadUpdated struct {
+	Head tongo.BlockIDExt
+	Conn *connection
 }
 
 func (c *connection) Run(ctx context.Context) {
 	for {
-		var seqno uint32
+		var head tongo.BlockIDExt
 		for {
 			res, err := c.client.LiteServerGetMasterchainInfo(ctx)
 			if err != nil {
@@ -24,12 +36,12 @@ func (c *connection) Run(ctx context.Context) {
 				time.Sleep(1000 * time.Millisecond)
 				continue
 			}
-			seqno = res.Last.Seqno
+			head = res.Last.ToBlockIdExt()
 			break
 		}
-		c.setMasterSeqno(seqno)
+		c.SetMasterHead(head)
 		for {
-			if err := c.client.WaitMasterchainSeqno(ctx, seqno+1, 15_000); err != nil {
+			if err := c.client.WaitMasterchainSeqno(ctx, head.Seqno+1, 15_000); err != nil {
 				// TODO: log error
 				time.Sleep(1000 * time.Millisecond)
 				// we want to request seqno again with LiteServerGetMasterchainInfo
@@ -37,11 +49,23 @@ func (c *connection) Run(ctx context.Context) {
 				// and it doesn't contain a block with the latest known seqno anymore.
 				break
 			}
-			seqno += 1
 			if ctx.Err() != nil {
 				return
 			}
-			c.setMasterSeqno(seqno)
+			res, err := c.client.LiteServerGetMasterchainInfo(ctx)
+			if err != nil {
+				// TODO: log error
+				time.Sleep(1000 * time.Millisecond)
+				// we want to request seqno again with LiteServerGetMasterchainInfo
+				// to avoid situation when this server has been offline for too long,
+				// and it doesn't contain a block with the latest known seqno anymore.
+				break
+			}
+			if ctx.Err() != nil {
+				return
+			}
+			head = res.Last.ToBlockIdExt()
+			c.SetMasterHead(head)
 		}
 	}
 }
@@ -51,18 +75,28 @@ func (c *connection) IsOK() bool {
 	return c.client.IsOK()
 }
 
+func (c *connection) ID() int {
+	return c.id
+}
+
 func (c *connection) Client() *liteclient.Client {
 	return c.client
 }
 
-func (c *connection) MasterSeqno() uint32 {
+func (c *connection) MasterHead() tongo.BlockIDExt {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.masterSeqno
+	return c.masterHead
 }
 
-func (c *connection) setMasterSeqno(seqno uint32) {
+func (c *connection) SetMasterHead(head tongo.BlockIDExt) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.masterSeqno = seqno
+	if head.Seqno > c.masterHead.Seqno {
+		c.masterHead = head
+		c.masterHeadUpdatedCh <- masterHeadUpdated{
+			Head: head,
+			Conn: c,
+		}
+	}
 }

--- a/liteapi/pool/failover_pool.go
+++ b/liteapi/pool/failover_pool.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -26,14 +27,20 @@ type FailoverPool struct {
 	conns              []conn
 	updateBestInterval time.Duration
 
-	mu       sync.RWMutex
-	bestConn conn
+	masterHeadUpdatedCh chan masterHeadUpdated
+
+	mu         sync.RWMutex
+	bestConn   conn
+	waitListID uint64
+	waitList   map[uint64]chan tongo.BlockIDExt
 }
 
 // conn contains all methods needed by a pool.
 // used to implement tests.
 type conn interface {
-	MasterSeqno() uint32
+	ID() int
+	MasterHead() tongo.BlockIDExt
+	SetMasterHead(tongo.BlockIDExt)
 	IsOK() bool
 	Client() *liteclient.Client
 	Run(ctx context.Context)
@@ -42,14 +49,25 @@ type conn interface {
 // NewFailoverPool returns a new instance of a failover pool.
 // The given list of clients is ordered by priority and starts with a connection with the highest priority.
 func NewFailoverPool(clients []*liteclient.Client) *FailoverPool {
+	if len(clients) == 0 {
+		panic("empty list of clients")
+	}
 	conns := make([]conn, 0, len(clients))
-	for _, cli := range clients {
-		conns = append(conns, &connection{client: cli})
+	masterHeadUpdatedCh := make(chan masterHeadUpdated, 10)
+
+	for connID, cli := range clients {
+		conns = append(conns, &connection{
+			id:                  connID,
+			client:              cli,
+			masterHeadUpdatedCh: masterHeadUpdatedCh,
+		})
 	}
 	return &FailoverPool{
-		conns:              conns,
-		updateBestInterval: updateBestConnectionInterval,
-		bestConn:           conns[0],
+		conns:               conns,
+		updateBestInterval:  updateBestConnectionInterval,
+		bestConn:            conns[0],
+		waitList:            map[uint64]chan tongo.BlockIDExt{},
+		masterHeadUpdatedCh: masterHeadUpdatedCh,
 	}
 }
 
@@ -57,12 +75,17 @@ func (p *FailoverPool) Run(ctx context.Context) {
 	for _, c := range p.conns {
 		go c.Run(ctx)
 	}
+	tickTock := time.NewTicker(p.updateBestInterval)
+	defer tickTock.Stop()
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
-		case <-time.After(p.updateBestInterval):
+		case <-tickTock.C:
 			p.updateBest()
+		case update := <-p.masterHeadUpdatedCh:
+			p.notifySubscribers(update)
 		}
 	}
 }
@@ -71,7 +94,7 @@ func (p *FailoverPool) Run(ctx context.Context) {
 func (p *FailoverPool) updateBest() {
 	var maxSeqno uint32
 	for _, c := range p.conns {
-		masterSeqno := c.MasterSeqno()
+		masterSeqno := c.MasterHead().Seqno
 		if maxSeqno < masterSeqno {
 			maxSeqno = masterSeqno
 		}
@@ -81,7 +104,7 @@ func (p *FailoverPool) updateBest() {
 		if !c.IsOK() {
 			continue
 		}
-		if c.MasterSeqno()+1 >= maxSeqno {
+		if c.MasterHead().Seqno+1 >= maxSeqno {
 			p.setBestConnection(c)
 			return
 		}
@@ -95,24 +118,123 @@ func (p *FailoverPool) setBestConnection(conn conn) {
 }
 
 func (p *FailoverPool) bestConnection() conn {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	return p.bestConn
 }
 
-func (p *FailoverPool) BestMasterchainServer() *liteclient.Client {
-	return p.bestConnection().Client()
+type MasterchainInfoClient struct {
+	conn conn
 }
 
-func (p *FailoverPool) BestServerByAccountID(tongo.AccountID) (*liteclient.Client, error) {
-	return p.BestMasterchainServer(), nil
+func (s *MasterchainInfoClient) LiteServerGetMasterchainInfoExt(ctx context.Context, request liteclient.LiteServerGetMasterchainInfoExtRequest) (res liteclient.LiteServerMasterchainInfoExtC, err error) {
+	info, err := s.conn.Client().LiteServerGetMasterchainInfoExt(ctx, request)
+	if err != nil {
+		return liteclient.LiteServerMasterchainInfoExtC{}, err
+	}
+	s.conn.SetMasterHead(info.Last.ToBlockIdExt())
+	return info, err
 }
 
-func (p *FailoverPool) BestServerByBlockID(tongo.BlockID) (*liteclient.Client, error) {
-	return p.BestMasterchainServer(), nil
+func (s *MasterchainInfoClient) LiteServerGetMasterchainInfo(ctx context.Context) (liteclient.LiteServerMasterchainInfoC, error) {
+	info, err := s.conn.Client().LiteServerGetMasterchainInfo(ctx)
+	if err != nil {
+		return liteclient.LiteServerMasterchainInfoC{}, err
+	}
+	s.conn.SetMasterHead(info.Last.ToBlockIdExt())
+	return info, err
+}
+
+func (p *FailoverPool) BestMasterchainInfoClient() *MasterchainInfoClient {
+	return &MasterchainInfoClient{
+		conn: p.bestConnection(),
+	}
+}
+
+// BestMasterchainClient returns a liteclient and its known masterchain head.
+func (p *FailoverPool) BestMasterchainClient(ctx context.Context) (*liteclient.Client, tongo.BlockIDExt, error) {
+	bestConnection := p.bestConnection()
+	masterHead := bestConnection.MasterHead()
+	if masterHead.Seqno > 0 {
+		return bestConnection.Client(), bestConnection.MasterHead(), nil
+	}
+	// so this client is not initialized yet,
+	// let's wait for it to be initialized.
+	waitID, ch := p.subscribe(1)
+	defer p.unsubscribe(waitID)
+
+	select {
+	case <-ctx.Done():
+		return nil, tongo.BlockIDExt{}, ctx.Err()
+	case head := <-ch:
+		return bestConnection.Client(), head, nil
+	}
+}
+
+// BestClientByAccountID returns a liteclient and its known masterchain head.
+func (p *FailoverPool) BestClientByAccountID(ctx context.Context, accountID tongo.AccountID) (*liteclient.Client, tongo.BlockIDExt, error) {
+	return p.BestMasterchainClient(ctx)
+}
+
+// BestClientByBlockID returns a liteclient and its known masterchain head.
+func (p *FailoverPool) BestClientByBlockID(ctx context.Context, blockID tongo.BlockID) (*liteclient.Client, error) {
+	server, _, err := p.BestMasterchainClient(ctx)
+	return server, err
 }
 
 // ConnectionsNumber returns a number of connections in this pool.
 func (p *FailoverPool) ConnectionsNumber() int {
 	return len(p.conns)
+}
+
+func (p *FailoverPool) notifySubscribers(update masterHeadUpdated) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if update.Conn.ID() != p.bestConn.ID() {
+		return
+	}
+	for _, ch := range p.waitList {
+		ch <- update.Head
+	}
+}
+
+func (p *FailoverPool) subscribe(seqno uint32) (uint64, chan tongo.BlockIDExt) {
+	ch := make(chan tongo.BlockIDExt, 1)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	head := p.bestConn.MasterHead()
+	if head.Seqno >= seqno {
+		ch <- head
+		return 0, ch
+	}
+	p.waitListID++
+	p.waitList[p.waitListID] = ch
+	return p.waitListID, ch
+}
+
+func (p *FailoverPool) unsubscribe(waitID uint64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.waitList, waitID)
+}
+
+func (p *FailoverPool) WaitMasterchainSeqno(ctx context.Context, seqno uint32, timeout time.Duration) error {
+	waitID, ch := p.subscribe(seqno)
+	defer p.unsubscribe(waitID)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(timeout):
+			return fmt.Errorf("timeout")
+		case head := <-ch:
+			if head.Seqno >= seqno {
+				return nil
+			}
+		}
+	}
 }

--- a/liteapi/pool/failover_pool_test.go
+++ b/liteapi/pool/failover_pool_test.go
@@ -3,7 +3,9 @@ package pool
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/tonkeeper/tongo"
 	"github.com/tonkeeper/tongo/liteclient"
 )
 
@@ -11,6 +13,17 @@ type mockConn struct {
 	id    int
 	seqno uint32
 	isOK  bool
+}
+
+func (m *mockConn) ID() int {
+	return 0
+}
+
+func (m *mockConn) MasterHead() tongo.BlockIDExt {
+	return tongo.BlockIDExt{BlockID: tongo.BlockID{Seqno: m.seqno}}
+}
+
+func (m *mockConn) SetMasterHead(ext tongo.BlockIDExt) {
 }
 
 func (m *mockConn) MasterSeqno() uint32 {
@@ -85,7 +98,8 @@ func TestFailoverPool_updateBest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := &FailoverPool{
-				conns: tt.conns,
+				conns:              tt.conns,
+				updateBestInterval: time.Second,
 			}
 			ctx := context.Background()
 			go p.Run(ctx)


### PR DESCRIPTION
   This commit does the following:
    * change the default number of connections in liteapi.Client's pool to 1
    * remove liteapi.Client's internal cache of masterhead * add WaitMasterchainSeqno to liteapi.Client to wait for a masterchain block with a given seqno