### PR TITLE
tvm.SetVerbosityLevel affects all instances of tvm emulator

### DIFF
--- a/abi/decoder_test.go
+++ b/abi/decoder_test.go
@@ -165,10 +165,6 @@ func TestSimpleGetMethod(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			err = emulator.SetVerbosityLevel(1)
-			if err != nil {
-				t.Fatal(err)
-			}
 			for _, methodID := range c.GetMethods {
 				_, ok := KnownSimpleGetMethods[methodID]
 				if !ok {

--- a/examples/tvm/main.go
+++ b/examples/tvm/main.go
@@ -32,7 +32,7 @@ func main() {
 		panic(err)
 	}
 
-	err = emulator.SetVerbosityLevel(1)
+	err = tvm.SetVerbosityLevel(1)
 	if err != nil {
 		panic(err)
 	}

--- a/tvm/tvmExecutor.go
+++ b/tvm/tvmExecutor.go
@@ -41,6 +41,8 @@ type Options struct {
 
 type Option func(o *Options)
 
+// WithVerbosityLevel sets verbosity level of a TVM emulator instance.
+// TODO: find a way to expose logs to the caller.
 func WithVerbosityLevel(level txemulator.VerbosityLevel) Option {
 	return func(o *Options) {
 		o.verbosityLevel = level
@@ -135,9 +137,17 @@ func destroy(e *Emulator) {
 	C.tvm_emulator_destroy(e.emulator)
 }
 
-// SetVerbosityLevel
+func init() {
+	if err := SetVerbosityLevel(0); err != nil {
+		// TODO: replace Printf with logger interface
+		fmt.Printf("SetVerbosityLevel() failed: %v\n", err)
+	}
+}
+
+// SetVerbosityLevel sets verbosity level of TVM emulator.
+// This is a global setting that affects all emulators.
 // verbosity level (0 - never, 1 - error, 2 - warning, 3 - info, 4 - debug)
-func (e *Emulator) SetVerbosityLevel(level int) error {
+func SetVerbosityLevel(level int) error {
 	ok := C.emulator_set_verbosity_level(C.int(level))
 	if !ok {
 		return fmt.Errorf("set VerbosityLevel error")

--- a/tvm/tvmExecutor_test.go
+++ b/tvm/tvmExecutor_test.go
@@ -30,12 +30,6 @@ func TestRunGetMethod(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	err = emulator.SetVerbosityLevel(1)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	code, res, err := emulator.RunSmcMethod(context.Background(), account, "get_nft_address_by_index", tlb.VmStack{val})
 	if err != nil {
 		t.Fatal(err)
@@ -64,12 +58,6 @@ func TestRunGetMethod_MYADDR(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	err = emulator.SetVerbosityLevel(16)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	fmt.Printf("%v\n", account)
 	code, res, err := emulator.RunSmcMethod(context.Background(), account, "get_my_addr", tlb.VmStack{})
 	if err != nil {


### PR DESCRIPTION
   SetVerbosityLevel method on a tvm emulator instance turned out to
affect all instances of the emulator.

   So this commit removes a receiver and now SetVerbosityLevel is a
package level function.