### PR TITLE
public access to connection pool

### DIFF
--- a/liteapi/client.go
+++ b/liteapi/client.go
@@ -1089,3 +1089,7 @@ func (c *Client) GetNetworkGlobalID(ctx context.Context) (int32, error) {
 	c.networkGlobalID = &block.GlobalId
 	return block.GlobalId, nil
 }
+
+func (c *Client) Pool() *pool.ConnPool {
+	return c.pool
+}


### PR DESCRIPTION
Sometime methods inside client (`client.LookupBlock` as example) select not the best connection and we don't have possibility to override method without public access to connection pool. That MR maybe not the best solution, but it help do something like: 

```
	client, _, err := c.Pool().BestMasterchainClient(ctx)
	if err != nil {
		return ton.BlockIDExt{}, tlb.BlockInfo{}, err
	}
```