### PR TITLE
refactor: use slices.Equal to simplify code

### DIFF
--- a/tlb/primitives_test.go
+++ b/tlb/primitives_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"math/big"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/tonkeeper/tongo/boc"
@@ -276,23 +277,12 @@ func TestHashmapAug(t *testing.T) {
 			t.Fatal("invalid suffix", c.Name)
 		}
 
-		if !equal(h.H.Values(), c.values) {
+		if !slices.Equal(h.H.Values(), c.values) {
 			t.Fatal("invalid values", c.Name)
 		}
 	}
 }
 
-func equal[T comparable](a, b []T) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
 
 func testJSON[T any](t *testing.T, data T) {
 	bytes, err := json.Marshal(data)


### PR DESCRIPTION
In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).