### PR TITLE
chore: remove unused min func

### DIFF
--- a/tlb/dns.go
+++ b/tlb/dns.go
@@ -172,13 +172,6 @@ func (t DNSText) MarshalTLB(c *boc.Cell, encoder *Encoder) error {
 	return nil
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-
 func (r *DNSRecord) UnmarshalTLB(c *boc.Cell, decoder *Decoder) error {
 	t, err := c.ReadUint(16)
 	if err != nil {


### PR DESCRIPTION
Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 