### PR TITLE
fix incorrect block encoding

### DIFF
--- a/ton/block.go
+++ b/ton/block.go
@@ -55,10 +55,10 @@ func NewTonBlockId(fileHash, rootHash Bits256, seqno uint32, shard uint64, workc
 }
 
 func (id BlockIDExt) String() string {
-	return fmt.Sprintf("(%d,%x,%d,%x,%x)", id.Workchain, id.Shard, id.Seqno, id.RootHash, id.FileHash)
+	return fmt.Sprintf("(%d,%016x,%d,%x,%x)", id.Workchain, id.Shard, id.Seqno, id.RootHash, id.FileHash)
 }
 func (id BlockID) String() string {
-	return fmt.Sprintf("(%d,%x,%d)", id.Workchain, id.Shard, id.Seqno)
+	return fmt.Sprintf("(%d,%016x,%d)", id.Workchain, id.Shard, id.Seqno)
 }
 
 func getParents(blkPrevInfo tlb.BlkPrevInfo, afterSplit, afterMerge bool, shard uint64, workchain int32) ([]BlockIDExt, error) {


### PR DESCRIPTION
shard is a  fixed-length bitmask so all digits are significant. normal person can't detect difference between 800000000000000 and 8000000000000000 but can between 0800000000000000 and 8000000000000000