### PR TITLE
Add ABI for Grambo

### DIFF
--- a/abi/schemas/grambo.xml
+++ b/abi/schemas/grambo.xml
@@ -1,0 +1,224 @@
+<abi>
+    <types>
+        trade_fees#_
+        referrer_fee:(VarUInteger 16)
+        deployer_fee:(VarUInteger 16)
+        platform_fee:(VarUInteger 16)
+        = GramboTradeFees;
+
+        sell_params#_
+        min_ton_out:(VarUInteger 16)
+        referrer:MsgAddress
+        custom_payload:(Maybe ^Cell) = GramboSellParams;
+
+        _#_ collected_ton:(VarUInteger 16)
+        tokens_sold:(VarUInteger 16)
+        graduated:bool
+        deployer:MsgAddress
+        fee_address:MsgAddress = GramboCurveState;
+
+        _#_ stonfi_router:MsgAddress
+        pton_wallet:MsgAddress = GramboDexConfig;
+
+        _#_ virtual_ton_reserve:(VarUInteger 16)
+        ton_target:(VarUInteger 16)
+        factory:MsgAddress
+        total_supply:(VarUInteger 16)
+        seed:uint256
+        curve_state:^GramboCurveState
+        wallet_code:^Cell
+        metadata:^Cell
+        dex_config:^GramboDexConfig = GramboMasterStorage;
+
+        _#_ activated:bool
+        balance:(VarUInteger 16)
+        owner:MsgAddress
+        master:MsgAddress = GramboWalletStorage;
+    </types>
+
+    <interface name="grambo_registry">
+        <get_method name="get_deploy_config" version="grambo" />
+        <msg_in>
+            <internal name="grambo_deploy" />
+            <internal name="grambo_update_data" />
+            <internal name="grambo_update_code" />
+        </msg_in>
+        <msg_out>
+            <internal name="grambo_launch" />
+        </msg_out>
+        <error code="65299">Invalid curve parameters</error>
+        <error code="65347">Unauthorized</error>
+        <error code="65360">Insufficient message value</error>
+    </interface>
+
+    <interface name="grambo_jetton_master" inherits="jetton_master">
+        <get_method name="get_amount_out" version="grambo" />
+        <get_method name="get_ton_out" version="grambo" />
+        <get_method name="get_curve_state" version="grambo" />
+        <msg_in>
+            <internal name="grambo_launch" />
+            <internal name="grambo_buy" />
+            <internal name="grambo_sell_notification" />
+            <internal name="grambo_unlock_wallet" />
+            <internal name="grambo_withdraw" />
+        </msg_in>
+        <msg_out>
+            <internal name="grambo_activate_wallet" />
+            <ext_out name="grambo_swap_event" />
+            <ext_out name="grambo_graduate_event" />
+        </msg_out>
+        <error code="74">Unauthorized</error>
+        <error code="65296">Already launched</error>
+        <error code="65344">Slippage error</error>
+        <error code="65347">Unauthorized</error>
+        <error code="65360">Insufficient value or balance</error>
+        <error code="65397">Not graduated</error>
+        <error code="65398">Already graduated</error>
+    </interface>
+
+    <interface name="grambo_jetton_wallet" inherits="jetton_wallet">
+        <get_method name="get_wallet_status" version="grambo" />
+        <msg_in>
+            <internal name="grambo_activate_wallet" />
+        </msg_in>
+        <msg_out>
+            <internal name="grambo_sell_notification" />
+        </msg_out>
+        <error code="65397">Wallet not activated</error>
+    </interface>
+
+    <get_method name="get_deploy_config">
+        <output version="grambo" fixed_length="true">
+            <tinyint name="deploy_fee">coins</tinyint>
+            <slice name="fee_collector">msgaddress</slice>
+            <slice name="stonfi_router">msgaddress</slice>
+            <slice name="stonfi_router_pton_wallet">msgaddress</slice>
+        </output>
+    </get_method>
+
+    <get_method name="get_amount_out">
+        <input>
+            <tinyint name="ton_in">coins</tinyint>
+        </input>
+        <output version="grambo" fixed_length="true">
+            <int name="tokens_out">int257</int>
+        </output>
+    </get_method>
+
+    <get_method name="get_ton_out">
+        <input>
+            <int name="tokens_in">int257</int>
+        </input>
+        <output version="grambo" fixed_length="true">
+            <tinyint name="ton_out">coins</tinyint>
+        </output>
+    </get_method>
+
+    <get_method name="get_curve_state">
+        <output version="grambo" fixed_length="true">
+            <tinyint name="virtual_ton_reserve">coins</tinyint>
+            <tinyint name="ton_target">coins</tinyint>
+            <tinyint name="collected_ton">coins</tinyint>
+            <int name="tokens_sold">int257</int>
+            <bool name="graduated">bool</bool>
+        </output>
+    </get_method>
+
+    <get_method name="get_wallet_status">
+        <output version="grambo" fixed_length="true">
+            <bool name="activated">bool</bool>
+        </output>
+    </get_method>
+
+    <internal name="grambo_deploy">
+        deploy2#0d4295e0
+        query_id:uint64
+        metadata:^Cell
+        ton_target:(VarUInteger 16)
+        prebuy_amount:(VarUInteger 16)
+        = InternalMsgBody;
+    </internal>
+
+    <internal name="grambo_update_data">
+        update_data#20b031d9
+        new_data:^Cell = InternalMsgBody;
+    </internal>
+
+    <internal name="grambo_update_code">
+        update_code#61d196c1
+        new_code:^Cell = InternalMsgBody;
+    </internal>
+
+    <internal name="grambo_launch">
+        launch#372f1ae3
+        query_id:uint64
+        buyer:MsgAddress
+        virtual_ton_reserve:(VarUInteger 16)
+        ton_target:(VarUInteger 16)
+        prebuy_amount:(VarUInteger 16)
+        = InternalMsgBody;
+    </internal>
+
+    <internal name="grambo_buy">
+        buy#2f54494e
+        query_id:uint64
+        ton_amount:(VarUInteger 16)
+        recipient:MsgAddress
+        min_tokens_out:(VarUInteger 16)
+        referrer:MsgAddress
+        custom_payload:(Maybe ^Cell)
+        = InternalMsgBody;
+    </internal>
+
+    <internal name="grambo_sell_notification">
+        sell_notification#31fc1276
+        query_id:uint64
+        amount:(VarUInteger 16)
+        from:MsgAddress
+        response_destination:MsgAddress
+        sell_params:(Maybe ^GramboSellParams)
+        = InternalMsgBody;
+    </internal>
+
+    <internal name="grambo_unlock_wallet">
+        unlock_wallet#7966410f
+        query_id:uint64
+        owner:MsgAddress
+        = InternalMsgBody;
+    </internal>
+
+    <internal name="grambo_withdraw">
+        withdraw#43e84bb5
+        query_id:uint64
+        amount:(VarUInteger 16)
+        = InternalMsgBody;
+    </internal>
+
+    <internal name="grambo_activate_wallet">
+        activate_wallet#6b75d3e2
+        query_id:uint64
+        = InternalMsgBody;
+    </internal>
+
+    <ext_out name="grambo_swap_event">
+        swap_event#5025398e
+        query_id:uint64
+        recipient:MsgAddress
+        is_buy:bool
+        new_collected_ton:(VarUInteger 16)
+        ton_amount:(VarUInteger 16)
+        token_amount:(VarUInteger 16)
+        referrer:MsgAddress
+        fees:^GramboTradeFees
+        custom_payload:(Maybe ^Cell)
+        = ExtOutMsgBody;
+    </ext_out>
+
+    <ext_out name="grambo_graduate_event">
+        graduate_event#0ab3d75c
+        query_id:uint64
+        ton_to_dex:(VarUInteger 16)
+        tokens_to_dex:(VarUInteger 16)
+        = ExtOutMsgBody;
+    </ext_out>
+</abi>


### PR DESCRIPTION
## Add ABI for Grambo

This PR adds ABI definitions for [Grambo](https://Grambo.fun), a memecoin launchpad ("memepad") on TON.

### What is Grambo?
Grambo is a social token launchpad built for the GRAM ecosystem. Grambo:
- Enables degens to create and launch tokens - no presale, no team allocation, no rugs.
- Lets users deploy Jettons tokens on The Open Network, through the grambo.fun frontend interface.

Docs: https://docs.grambo.fun/introduction

### Contracts covered
- **`grambo_registry`**: deploys new jettons.
- **`grambo_jetton_master`**: the bonding curve: buy/sell against the curve, swap + graduate events, curve-state get methods.
- **`grambo_jetton_wallet`**: per-holder wallet with an activation gate and sell-notification flow.

### Samples contract address
Grambo Registry [TonViewer](https://tonviewer.com/EQApINKePo4Vq1l_W6ZAvYkJf5ORc9eamxxCtFcb79pfCM-h):
```
EQApINKePo4Vq1l_W6ZAvYkJf5ORc9eamxxCtFcb79pfCM-h
```
Grambo Jetton Master [TonViewer](https://tonviewer.com/EQBom4slLIetxxKbAMYRD61BQwsxRnR_Tm0AO5ejiXsSYuYT):
```
EQBom4slLIetxxKbAMYRD61BQwsxRnR_Tm0AO5ejiXsSYuYT
```
Grambo Jetton Wallet [TonViewer](https://tonviewer.com/EQCZ6IqkPa_exoJ992TM64ujXF1qEq5IL4yyvOVm0KIz4fPW):
```
EQCZ6IqkPa_exoJ992TM64ujXF1qEq5IL4yyvOVm0KIz4fPW
```

> [!NOTE]
> Maintainers needs to re-generate ABI after merging.