### PR TITLE
fix(liteclient): write both magics in auth-complete payload (#463)

### DIFF
--- a/liteclient/auth_complete_test.go
+++ b/liteclient/auth_complete_test.go
@@ -1,0 +1,63 @@
+package liteclient
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/binary"
+	"testing"
+)
+
+// Regression for #463: sendAuthComplete built the payload with
+//
+//	payload := make([]byte, 4)
+//	binary.LittleEndian.PutUint32(payload, magicTcpAuthentificationComplete)
+//	binary.LittleEndian.PutUint32(payload, magicPubKey)
+//
+// so the second PutUint32 overwrote the first at offset 0. The message type
+// magic (magicTcpAuthentificationComplete) was dropped and the payload was
+// 4 bytes short. The serialized tcp.authentificationComplete message must be:
+//
+//	magicTcpAuthentificationComplete (4) | magicPubKey (4) | pubKey (32) |
+//	len(signature) prefix | signature | zero padding to a 4-byte boundary.
+func TestBuildAuthCompletePayloadLayout(t *testing.T) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature := ed25519.Sign(priv, []byte("nonce"))
+
+	payload := buildAuthCompletePayload(pub, signature)
+
+	// Both magics must be present in their own 4-byte slots.
+	gotMsgMagic := binary.LittleEndian.Uint32(payload[0:4])
+	if gotMsgMagic != magicTcpAuthentificationComplete {
+		t.Fatalf("message magic: got %#x, want %#x (it was overwritten before the fix)",
+			gotMsgMagic, uint32(magicTcpAuthentificationComplete))
+	}
+	gotPubMagic := binary.LittleEndian.Uint32(payload[4:8])
+	if gotPubMagic != magicPubKey {
+		t.Fatalf("pubkey magic: got %#x, want %#x", gotPubMagic, uint32(magicPubKey))
+	}
+
+	// The 32-byte public key follows the two magics.
+	if !bytes.Equal(payload[8:8+ed25519.PublicKeySize], pub) {
+		t.Fatalf("public key not serialized at offset 8")
+	}
+
+	// The signature must survive round-trip: 1-byte length prefix (64 < 254)
+	// then the signature bytes.
+	sigStart := 8 + ed25519.PublicKeySize
+	if int(payload[sigStart]) != len(signature) {
+		t.Fatalf("signature length prefix: got %d, want %d", payload[sigStart], len(signature))
+	}
+	gotSig := payload[sigStart+1 : sigStart+1+len(signature)]
+	if !bytes.Equal(gotSig, signature) {
+		t.Fatalf("signature not serialized correctly")
+	}
+
+	// Payload must be padded to a 4-byte boundary.
+	if len(payload)%4 != 0 {
+		t.Fatalf("payload not aligned to 4 bytes: len=%d", len(payload))
+	}
+}

--- a/liteclient/connection.go
+++ b/liteclient/connection.go
@@ -328,14 +328,8 @@ func (c *Connection) sendAuthComplete(received Packet) error {
 
 	signature := ed25519.Sign(c.authKey, append(append([]byte{}, c.nonce...), nonce...))
 
-	payload := make([]byte, 4)
-	binary.LittleEndian.PutUint32(payload, magicTcpAuthentificationComplete)
-	binary.LittleEndian.PutUint32(payload, magicPubKey)
 	pubKey := c.authKey.Public().(ed25519.PublicKey)
-	payload = append(payload, pubKey[:]...)
-	payload = append(payload, tl.EncodeLength(len(signature))...)
-	payload = append(payload, signature...)
-	payload = alignBytes(payload)
+	payload := buildAuthCompletePayload(pubKey, signature)
 
 	p, err := NewPacket(payload)
 	if err != nil {
@@ -346,4 +340,23 @@ func (c *Connection) sendAuthComplete(received Packet) error {
 		return fmt.Errorf("failed to send auth sign request, err: %w", err)
 	}
 	return nil
+}
+
+// buildAuthCompletePayload serializes a tcp.authentificationComplete message:
+//
+//	tcp.authentificationComplete key:PublicKey signature:bytes = tcp.Message
+//
+// where key:PublicKey is itself serialized as pub.ed25519 key:int256 = PublicKey.
+// The layout is therefore the message type magic, the PublicKey constructor magic,
+// the 32-byte public key, and the length-prefixed signature. The two magics must
+// occupy distinct 4-byte slots; writing both to the same offset dropped the
+// message type prefix (see #463).
+func buildAuthCompletePayload(pubKey ed25519.PublicKey, signature []byte) []byte {
+	payload := make([]byte, 8)
+	binary.LittleEndian.PutUint32(payload[:4], magicTcpAuthentificationComplete)
+	binary.LittleEndian.PutUint32(payload[4:8], magicPubKey)
+	payload = append(payload, pubKey[:]...)
+	payload = append(payload, tl.EncodeLength(len(signature))...)
+	payload = append(payload, signature...)
+	return alignBytes(payload)
 }


### PR DESCRIPTION
## What

Closes #463.

`sendAuthComplete` (`liteclient/connection.go`) built the `tcp.authentificationComplete` payload like this:

```go
payload := make([]byte, 4)
binary.LittleEndian.PutUint32(payload, magicTcpAuthentificationComplete)
binary.LittleEndian.PutUint32(payload, magicPubKey)
```

Both `PutUint32` calls write to offset 0 of the same 4-byte buffer, so the second write (`magicPubKey`) immediately overwrites the first (`magicTcpAuthentificationComplete`). The auth-complete message is therefore sent with the wrong type prefix and is 4 bytes short.

## Cause

The TL schema is:

```
tcp.authentificationComplete key:PublicKey signature:bytes = tcp.Message
pub.ed25519 key:int256 = PublicKey
```

so the serialized layout must be **two distinct magics** — the message-type magic followed by the `PublicKey` constructor magic — then the 32-byte key and the length-prefixed signature. The buffer needs 8 bytes for the two magics, not 4.

## Fix

Write the two magics into distinct 4-byte slots, and extract the payload construction into a pure `buildAuthCompletePayload(pubKey, signature)` helper so the byte layout is unit-testable without a live connection:

```go
payload := make([]byte, 8)
binary.LittleEndian.PutUint32(payload[:4], magicTcpAuthentificationComplete)
binary.LittleEndian.PutUint32(payload[4:8], magicPubKey)
```

## Tests

Added `liteclient/auth_complete_test.go`, which asserts the exact byte layout: message magic at `[0:4]`, pubkey magic at `[4:8]`, the public key at offset 8, the length-prefixed signature after it, and 4-byte alignment.

**Verified genuine RED→GREEN:** with the original construction restored, the test fails with `message magic: got 0x4813b4c6, want 0xf7ad9ea6` — i.e. it catches the exact overwrite; with the fix it passes.

## Validation (real results, Go 1.24.5)

- `go test ./liteclient/ -run TestBuildAuthCompletePayloadLayout`: **PASS**
- `go build ./...`: **success**
- `gofmt -l` and `go vet ./liteclient/`: clean

Note: the package's `client_test.go` tests (e.g. `TestGeneratedMethod3`) connect to a live lite server and fail in a sandbox without outbound network — I confirmed they fail identically on a clean `master` checkout, so that is unrelated to this change.

First-time contributor here — happy to adjust the helper's name/placement or the test if you'd prefer a different approach.
