### PR TITLE
derive cell level masks instead of storing them

### DIFF
--- a/boc/boc.go
+++ b/boc/boc.go
@@ -209,6 +209,8 @@ func deserializeCellData(cellData []byte, referenceIndexSize int) (*Cell, []int,
 	dataBytesSize := int(d2>>1) + int(d2%2)
 	fullfilledBytes := !((d2 % 2) > 0)
 	withHashes := (d1 & 0b10000) != 0
+	// the mask declared by d1 is not kept on the cell, it is only needed to know
+	// how many hashes and depths precede the cell data. See levelMaskOf.
 	mask := levelMask(d1 >> 5)
 
 	if withHashes {
@@ -220,10 +222,8 @@ func deserializeCellData(cellData []byte, referenceIndexSize int) (*Cell, []int,
 		// the first byte of an exotic cell stores the cell's type.
 		exoticType := CellType(readNBytesUIntFromArray(1, cellData))
 		cell = NewCellExotic(exoticType)
-		cell.mask = mask
 	} else {
 		cell = NewCell()
-		cell.mask = mask
 	}
 
 	if len(cellData) < dataBytesSize+referenceIndexSize*refNum {
@@ -331,7 +331,7 @@ func (boc *bagOfCells) serializeBoc(rootCells []*Cell, idx bool, hasCrc32 bool, 
 	reps := make([][]byte, cellCount)
 	for i := cellCount - 1; i >= 0; i-- {
 		ci := cellInfos[i]
-		repr := ci.cell.bocReprWithoutRefs(ci.cell.mask)
+		repr := ci.cell.bocReprWithoutRefs(ci.mask)
 		for j := 0; j < ci.refsNumber; j++ {
 			var b [8]byte
 			k := cellCount - 1 - ci.refsIndex[j]
@@ -458,6 +458,10 @@ func (boc *bagOfCells) importCell(state *orderState, cell *Cell, depth int) (int
 	if err != nil {
 		return 0, err
 	}
+	mask, err := boc.hasher.levelMask(cell)
+	if err != nil {
+		return 0, err
+	}
 	if pos, ok := state.cells[hash]; ok {
 		state.cellList[pos].shouldCache = true
 		return pos, nil
@@ -488,7 +492,8 @@ func (boc *bagOfCells) importCell(state *orderState, cell *Cell, depth int) (int
 		wt:          sumChildWt,
 		refsIndex:   refs,
 		refsNumber:  refsNumber,
-		hashCount:   cell.mask.HashesCount(),
+		mask:        mask,
+		hashCount:   mask.HashesCount(),
 		newIndex:    -1,
 		isRootCell:  false,
 	}
@@ -502,6 +507,7 @@ type cellInfo struct {
 	wt          int
 	refsIndex   [4]int
 	refsNumber  int
+	mask        levelMask
 	hashCount   int
 	newIndex    int
 	isRootCell  bool

--- a/boc/cell.go
+++ b/boc/cell.go
@@ -17,6 +17,7 @@ var ErrCellRefsOverflow = errors.New("too many refs")
 var ErrNotEnoughRefs = errors.New("not enough refs")
 var ErrNotSingleRoot = errors.New("should be one root cell")
 var ErrDepthIsTooBig = errors.New("depth is too big")
+var ErrMalformedExoticCell = errors.New("malformed exotic cell")
 
 type CellType uint8
 
@@ -33,7 +34,8 @@ type Cell struct {
 	refs      [4]*Cell
 	refCursor int
 	cellType  CellType
-	mask      levelMask
+	// a cell has no level mask field on purpose: a stale mask makes a cell tree
+	// unserializable, see levelMaskOf.
 	// TODO: add capacity checking
 }
 
@@ -545,7 +547,6 @@ func (c *Cell) CopyCell() *Cell {
 		refs:      [4]*Cell{},
 		refCursor: c.refCursor,
 		cellType:  c.cellType,
-		mask:      c.mask,
 	}
 	for i, ref := range c.refs {
 		newC.refs[i] = ref.CopyCell()
@@ -660,8 +661,41 @@ func (c *Cell) bocReprWithoutRefs(mask levelMask) []byte {
 }
 
 // Level returns a level of this cell.
+// It returns 0 if the cell's level mask can't be derived, use LevelMask to get the error.
 func (c *Cell) Level() int {
-	return c.mask.Level()
+	mask, err := c.LevelMask()
+	if err != nil {
+		return 0
+	}
+	return levelMask(mask).Level()
+}
+
+// LevelMask returns a level mask of this cell derived from its type, content and refs.
+// It fails if this cell or one of its descendants is a malformed exotic cell.
+func (c *Cell) LevelMask() (uint8, error) {
+	imc, err := newImmutableCell(c, map[*Cell]*immutableCell{})
+	if err != nil {
+		return 0, err
+	}
+	return uint8(imc.mask), nil
+}
+
+// HashAtLevel returns a hash of this cell for the given level.
+//
+// Hash256 returns the hash of the highest level, which is what ton's Cell::get_hash() does.
+// Level 0 is the representation hash: for a cell tree containing pruned branches,
+// that is the hash of the original, unpruned tree.
+func (c *Cell) HashAtLevel(level int) ([32]byte, error) {
+	if level < 0 || level > maxLevel {
+		return [32]byte{}, fmt.Errorf("level must be in [0, %v], got %v", maxLevel, level)
+	}
+	imc, err := newImmutableCell(c, map[*Cell]*immutableCell{})
+	if err != nil {
+		return [32]byte{}, err
+	}
+	var h [32]byte
+	copy(h[:], imc.Hash(level))
+	return h, nil
 }
 
 func (c *Cell) GetMerkleRoot() ([32]byte, error) {

--- a/boc/hasher.go
+++ b/boc/hasher.go
@@ -24,6 +24,15 @@ func (h *Hasher) Hash(c *Cell) ([]byte, error) {
 	return c.hash(h.cache)
 }
 
+// levelMask returns the derived level mask of the given cell, reusing the hasher's cache.
+func (h *Hasher) levelMask(c *Cell) (levelMask, error) {
+	imm, err := newImmutableCell(c, h.cache)
+	if err != nil {
+		return 0, err
+	}
+	return imm.mask, nil
+}
+
 func (h *Hasher) HashString(c *Cell) (string, error) {
 	if s, ok := h.cacheHex[c]; ok {
 		return s, nil

--- a/boc/immutable_cell.go
+++ b/boc/immutable_cell.go
@@ -29,14 +29,12 @@ func newImmutableCell(c *Cell, cache map[*Cell]*immutableCell) (*immutableCell, 
 		return imm, nil
 	}
 	imm := &immutableCell{
-		mask:     c.mask,
 		cellType: c.cellType,
 		refs:     make([]*immutableCell, 0, c.RefsSize()),
-		hashes:   make([][]byte, 0, c.mask.HashesCount()),
-		depths:   make([]int, 0, c.mask.HashesCount()),
 		bitsBuf:  c.bits.buf,
 		bitsLen:  c.bits.len,
 	}
+	refMasks := make([]levelMask, 0, c.RefsSize())
 	for _, ref := range c.refs {
 		if ref == nil {
 			break
@@ -46,9 +44,18 @@ func newImmutableCell(c *Cell, cache map[*Cell]*immutableCell) (*immutableCell, 
 			return nil, err
 		}
 		imm.refs = append(imm.refs, immRef)
+		refMasks = append(refMasks, immRef.mask)
 	}
+	// a cell's level mask is derived from its type, content and refs, never taken
+	// from the cell itself - see levelMaskOf.
+	mask, err := levelMaskOf(c.cellType, c.bits.buf, c.bits.len, refMasks)
+	if err != nil {
+		return nil, err
+	}
+	imm.mask = mask
+	imm.hashes = make([][]byte, 0, mask.HashesCount())
+	imm.depths = make([]int, 0, mask.HashesCount())
 
-	mask := c.mask
 	level := mask.Level()
 
 	// the algorithm below is taken directly from ton-blockchain/ton
@@ -94,11 +101,11 @@ func newImmutableCell(c *Cell, cache map[*Cell]*immutableCell) (*immutableCell, 
 		x := sha256.New()
 		if hashIndex == offset {
 			// either i=0 or cellType=PrunedBranchCell
-			cellRepr := c.bocReprWithoutRefs(c.mask.Apply(i))
+			cellRepr := c.bocReprWithoutRefs(mask.Apply(i))
 			x.Write(cellRepr)
 		} else {
 			// i>0
-			x.Write([]byte{d1(c, c.mask.Apply(i)), d2(c)})
+			x.Write([]byte{d1(c, mask.Apply(i)), d2(c)})
 			x.Write(imm.hashes[hashIndex-offset-1])
 		}
 
@@ -171,7 +178,6 @@ func (ic *immutableCell) pruneCells(pruned map[*immutableCell]struct{}) (*Cell, 
 		// we are pruned
 		// let's replace this cell with a pruned branch cell
 		prunedCell := NewCell()
-		prunedCell.mask = 1
 		prunedCell.cellType = PrunedBranchCell
 		if err := prunedCell.WriteUint(1, 8); err != nil {
 			return nil, err
@@ -199,19 +205,13 @@ func (ic *immutableCell) pruneCells(pruned map[*immutableCell]struct{}) (*Cell, 
 		bits:     bits,
 		refs:     [4]*Cell{},
 		cellType: ic.cellType,
-		mask:     ic.mask,
 	}
-	mask := ic.mask
 	for i, ref := range ic.refs {
 		cell, err := ref.pruneCells(pruned)
 		if err != nil {
 			return nil, err
 		}
-		if cell.mask > 0 {
-			mask |= cell.mask
-		}
 		res.refs[i] = cell
 	}
-	res.mask = mask
 	return &res, nil
 }

--- a/boc/level_mask.go
+++ b/boc/level_mask.go
@@ -1,6 +1,9 @@
 package boc
 
-import "math/bits"
+import (
+	"fmt"
+	"math/bits"
+)
 
 // levelMask is a tricky way to keep track of two things simultaneously:
 // a cell level and a number of different hashes that makes sense to calculate for a cell.
@@ -27,4 +30,57 @@ func (m levelMask) IsSignificant(level uint32) bool {
 		return true
 	}
 	return (m>>(level-1))%2 != 0
+}
+
+// maxLevelMask is the largest level mask that fits into the 3 mask bits of a d1 byte.
+const maxLevelMask = levelMask(0b111)
+
+// levelMaskOf derives a cell's level mask from its type, its data and the level masks of
+// its refs, following ton-blockchain's DataCell::create:
+// https://github.com/ton-blockchain/ton/blob/master/crypto/vm/cells/CellBuilder.cpp
+//
+// A cell's level mask is never stored on the cell itself: it is a function of the cell's
+// content, so deriving it is the only way to keep it in sync with the tree. In particular
+// an ordinary parent inherits the union of its children's masks, while a merkle cell
+// shifts them right - a plain union would produce a wrong level for merkle proofs.
+func levelMaskOf(cellType CellType, bitsBuf []byte, bitsLen int, refs []levelMask) (levelMask, error) {
+	switch cellType {
+	case OrdinaryCell:
+		var mask levelMask
+		for _, ref := range refs {
+			mask |= ref
+		}
+		return mask, nil
+	case PrunedBranchCell:
+		if len(refs) != 0 {
+			return 0, fmt.Errorf("%w: pruned branch cell must have no refs, got %v", ErrMalformedExoticCell, len(refs))
+		}
+		if bitsLen < 16 || len(bitsBuf) < 2 {
+			return 0, fmt.Errorf("%w: pruned branch cell is too short: %v bits", ErrMalformedExoticCell, bitsLen)
+		}
+		// the second byte of a pruned branch cell stores the level mask of the cell it replaces.
+		mask := levelMask(bitsBuf[1])
+		if mask == 0 || mask > maxLevelMask {
+			return 0, fmt.Errorf("%w: invalid pruned branch level mask %v", ErrMalformedExoticCell, mask)
+		}
+		// a pruned branch cell stores a hash and a depth for every significant level
+		// of the original cell, on top of the two header bytes.
+		if want := 16 + (hashSize+depthSize)*8*mask.HashIndex(); bitsLen != want {
+			return 0, fmt.Errorf("%w: pruned branch cell with mask %v must have %v bits, got %v", ErrMalformedExoticCell, mask, want, bitsLen)
+		}
+		return mask, nil
+	case LibraryCell:
+		return 0, nil
+	case MerkleProofCell:
+		if len(refs) != 1 {
+			return 0, fmt.Errorf("%w: merkle proof cell must have exactly one ref, got %v", ErrMalformedExoticCell, len(refs))
+		}
+		return refs[0] >> 1, nil
+	case MerkleUpdateCell:
+		if len(refs) != 2 {
+			return 0, fmt.Errorf("%w: merkle update cell must have exactly two refs, got %v", ErrMalformedExoticCell, len(refs))
+		}
+		return (refs[0] | refs[1]) >> 1, nil
+	}
+	return 0, fmt.Errorf("%w: unknown cell type %v", ErrMalformedExoticCell, uint8(cellType))
 }

--- a/boc/level_mask_test.go
+++ b/boc/level_mask_test.go
@@ -1,0 +1,221 @@
+package boc
+
+import (
+	"errors"
+	"testing"
+)
+
+// newPrunedBranch builds a well-formed level-1 pruned branch cell
+// standing in for a cell with the given hash and depth.
+func newPrunedBranch(t *testing.T, hash []byte, depth int) *Cell {
+	t.Helper()
+	c := NewCellExotic(PrunedBranchCell)
+	if err := c.WriteUint(uint64(PrunedBranchCell), 8); err != nil {
+		t.Fatalf("write type: %v", err)
+	}
+	if err := c.WriteUint(1, 8); err != nil { // level mask of the replaced cell
+		t.Fatalf("write mask: %v", err)
+	}
+	if err := c.WriteBytes(hash); err != nil {
+		t.Fatalf("write hash: %v", err)
+	}
+	if err := c.WriteUint(uint64(depth), 16); err != nil {
+		t.Fatalf("write depth: %v", err)
+	}
+	c.ResetCounters()
+	return c
+}
+
+// declaredMasks returns the level mask each cell of the given boc declares in its d1 byte,
+// in serialization order (the root comes first).
+func declaredMasks(t *testing.T, bocBytes []byte) []levelMask {
+	t.Helper()
+	header, err := parseBocHeader(bocBytes)
+	if err != nil {
+		t.Fatalf("parseBocHeader() failed: %v", err)
+	}
+	data := header.cellsData
+	masks := make([]levelMask, 0, header.cellCount)
+	for i := 0; i < int(header.cellCount); i++ {
+		d1, d2 := data[0], data[1]
+		if d1&0b10000 != 0 {
+			t.Fatalf("cell %v unexpectedly serialized with hashes", i)
+		}
+		masks = append(masks, levelMask(d1>>5))
+		dataBytes := int(d2>>1) + int(d2%2)
+		data = data[2+dataBytes+header.sizeBytes*int(d1%8):]
+	}
+	return masks
+}
+
+// TestSerializeBoc_LevelMaskOfBuiltTree makes sure a cell tree built in memory
+// around a leveled cell declares the right level mask. Getting this wrong produces
+// a boc that ton rejects with "level mask mismatch".
+func TestSerializeBoc_LevelMaskOfBuiltTree(t *testing.T) {
+	pruned := newPrunedBranch(t, make([]byte, hashSize), 7)
+
+	root := NewCell()
+	if err := root.WriteUint(0xdeadbeef, 32); err != nil {
+		t.Fatalf("WriteUint() failed: %v", err)
+	}
+	// an intermediate ordinary cell must propagate the level up to the root
+	middle := NewCell()
+	if err := middle.AddRef(pruned); err != nil {
+		t.Fatalf("AddRef() failed: %v", err)
+	}
+	if err := root.AddRef(middle); err != nil {
+		t.Fatalf("AddRef() failed: %v", err)
+	}
+
+	if level := root.Level(); level != 1 {
+		t.Fatalf("root.Level() = %v, want 1", level)
+	}
+	bocBytes, err := root.ToBoc()
+	if err != nil {
+		t.Fatalf("ToBoc() failed: %v", err)
+	}
+	for i, mask := range declaredMasks(t, bocBytes) {
+		if mask != 1 {
+			t.Errorf("cell %v declares level mask %v, want 1", i, mask)
+		}
+	}
+	if _, err := DeserializeBoc(bocBytes); err != nil {
+		t.Fatalf("DeserializeBoc() failed: %v", err)
+	}
+}
+
+// TestCreateProof_MerkleProofLevelMask makes sure a merkle proof root shifts
+// its child's level mask right instead of inheriting it.
+func TestCreateProof_MerkleProofLevelMask(t *testing.T) {
+	root := NewCell()
+	for i := 0; i < 2; i++ {
+		ref, err := root.NewRef()
+		if err != nil {
+			t.Fatalf("NewRef() failed: %v", err)
+		}
+		if err := ref.WriteUint(uint64(i), 32); err != nil {
+			t.Fatalf("WriteUint() failed: %v", err)
+		}
+	}
+	rootHash, err := root.Hash256()
+	if err != nil {
+		t.Fatalf("Hash256() failed: %v", err)
+	}
+
+	prover, err := NewMerkleProver(root)
+	if err != nil {
+		t.Fatalf("NewMerkleProver() failed: %v", err)
+	}
+	cursor := prover.Cursor()
+	cursor.Ref(1).Prune()
+	proof, err := prover.CreateProof(cursor)
+	if err != nil {
+		t.Fatalf("CreateProof() failed: %v", err)
+	}
+
+	masks := declaredMasks(t, proof)
+	if masks[0] != 0 {
+		t.Errorf("merkle proof root declares level mask %v, want 0", masks[0])
+	}
+
+	proofRoot, err := DeserializeSingleRootBoc(proof)
+	if err != nil {
+		t.Fatalf("DeserializeSingleRootBoc() failed: %v", err)
+	}
+	if proofRoot.CellType() != MerkleProofCell {
+		t.Fatalf("proof root type = %v, want MerkleProofCell", proofRoot.CellType())
+	}
+	if level := proofRoot.Level(); level != 0 {
+		t.Errorf("proof root level = %v, want 0", level)
+	}
+	virtualRoot := proofRoot.Refs()[0]
+	if level := virtualRoot.Level(); level != 1 {
+		t.Errorf("virtual root level = %v, want 1", level)
+	}
+	// the proof must still be about the original tree
+	merkleRoot, err := proofRoot.GetMerkleRoot()
+	if err != nil {
+		t.Fatalf("GetMerkleRoot() failed: %v", err)
+	}
+	if merkleRoot != rootHash {
+		t.Errorf("merkle root = %x, want %x", merkleRoot, rootHash)
+	}
+	if hash, err := virtualRoot.HashAtLevel(0); err != nil || hash != rootHash {
+		t.Errorf("virtual root hash at level 0 = %x (err %v), want %x", hash, err, rootHash)
+	}
+}
+
+func TestLevelMaskOf(t *testing.T) {
+	prunedBits := 16 + (hashSize+depthSize)*8
+	testCases := []struct {
+		name     string
+		cellType CellType
+		bitsBuf  []byte
+		bitsLen  int
+		refs     []levelMask
+		want     levelMask
+		wantErr  bool
+	}{
+		{name: "ordinary without refs", cellType: OrdinaryCell, want: 0},
+		{name: "ordinary is a union of its refs", cellType: OrdinaryCell, refs: []levelMask{0b001, 0b100}, want: 0b101},
+		{name: "library is always level 0", cellType: LibraryCell, bitsBuf: []byte{2}, bitsLen: 264, want: 0},
+		{name: "merkle proof shifts its ref right", cellType: MerkleProofCell, refs: []levelMask{0b011}, want: 0b001},
+		{name: "merkle proof over a level 1 ref is level 0", cellType: MerkleProofCell, refs: []levelMask{0b001}, want: 0},
+		{name: "merkle proof without a ref", cellType: MerkleProofCell, wantErr: true},
+		{name: "merkle update shifts the union right", cellType: MerkleUpdateCell, refs: []levelMask{0b010, 0b101}, want: 0b011},
+		{name: "merkle update with a single ref", cellType: MerkleUpdateCell, refs: []levelMask{0b010}, wantErr: true},
+		{name: "pruned branch takes its mask from the data", cellType: PrunedBranchCell, bitsBuf: []byte{1, 1}, bitsLen: prunedBits, want: 1},
+		{name: "pruned branch with a zero mask", cellType: PrunedBranchCell, bitsBuf: []byte{1, 0}, bitsLen: prunedBits, wantErr: true},
+		{name: "pruned branch with an out of range mask", cellType: PrunedBranchCell, bitsBuf: []byte{1, 0b1000}, bitsLen: prunedBits, wantErr: true},
+		{name: "pruned branch with a truncated body", cellType: PrunedBranchCell, bitsBuf: []byte{1, 1}, bitsLen: prunedBits - 8, wantErr: true},
+		{name: "empty pruned branch", cellType: PrunedBranchCell, wantErr: true},
+		{name: "pruned branch with refs", cellType: PrunedBranchCell, bitsBuf: []byte{1, 1}, bitsLen: prunedBits, refs: []levelMask{0}, wantErr: true},
+		{name: "unknown cell type", cellType: CellType(42), wantErr: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mask, err := levelMaskOf(tc.cellType, tc.bitsBuf, tc.bitsLen, tc.refs)
+			if tc.wantErr {
+				if !errors.Is(err, ErrMalformedExoticCell) {
+					t.Fatalf("levelMaskOf() error = %v, want ErrMalformedExoticCell", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("levelMaskOf() failed: %v", err)
+			}
+			if mask != tc.want {
+				t.Errorf("levelMaskOf() = %b, want %b", mask, tc.want)
+			}
+		})
+	}
+}
+
+// TestMalformedExoticCell makes sure a broken exotic cell is reported
+// instead of producing a bogus hash or panicking on an out of range read.
+func TestMalformedExoticCell(t *testing.T) {
+	truncated := NewCellExotic(PrunedBranchCell)
+	if err := truncated.WriteUint(0x0101, 16); err != nil {
+		t.Fatalf("WriteUint() failed: %v", err)
+	}
+	truncated.ResetCounters()
+
+	if _, err := truncated.Hash256(); !errors.Is(err, ErrMalformedExoticCell) {
+		t.Errorf("Hash256() error = %v, want ErrMalformedExoticCell", err)
+	}
+	if _, err := truncated.ToBoc(); !errors.Is(err, ErrMalformedExoticCell) {
+		t.Errorf("ToBoc() error = %v, want ErrMalformedExoticCell", err)
+	}
+	if _, err := truncated.LevelMask(); !errors.Is(err, ErrMalformedExoticCell) {
+		t.Errorf("LevelMask() error = %v, want ErrMalformedExoticCell", err)
+	}
+
+	// and it must be reported through its parents too
+	parent := NewCell()
+	if err := parent.AddRef(truncated); err != nil {
+		t.Fatalf("AddRef() failed: %v", err)
+	}
+	if _, err := parent.ToBoc(); !errors.Is(err, ErrMalformedExoticCell) {
+		t.Errorf("ToBoc() error = %v, want ErrMalformedExoticCell", err)
+	}
+}

--- a/tlb/pruned_branch_test.go
+++ b/tlb/pruned_branch_test.go
@@ -47,9 +47,29 @@ func TestUnmarshalKeepsPrunedBranch(t *testing.T) {
 	t.Run("rebuild", func(t *testing.T) {
 		rebuilt := boc.NewCell()
 		require.Nil(t, Marshal(rebuilt, account))
-		h, err := rebuilt.Hash256()
+
+		// the rebuilt tree carries a pruned branch, so it is a level 1 cell,
+		// just like the tree it was decoded from.
+		mask, err := rebuilt.LevelMask()
+		require.Nil(t, err)
+		require.Equal(t, uint8(1), mask, "a tree with a pruned branch must not claim level 0")
+		originalMask, err := cell.LevelMask()
+		require.Nil(t, err)
+		require.Equal(t, originalMask, mask)
+
+		// level 0 is the representation hash: the hash of the original, unpruned account.
+		h, err := rebuilt.HashAtLevel(0)
 		require.Nil(t, err)
 		require.Equal(t, prunedAccountHash, hex.EncodeToString(h[:]))
+
+		// and marshalling must not change any hash of the decoded tree
+		for level := 0; level <= 3; level++ {
+			want, err := cell.HashAtLevel(level)
+			require.Nil(t, err)
+			got, err := rebuilt.HashAtLevel(level)
+			require.Nil(t, err)
+			require.Equal(t, hex.EncodeToString(want[:]), hex.EncodeToString(got[:]), "hash of level %v", level)
+		}
 	})
 
 	t.Run("restore pruned code", func(t *testing.T) {

--- a/tvm/level_mask_boc_test.go
+++ b/tvm/level_mask_boc_test.go
@@ -1,0 +1,78 @@
+package tvm
+
+import (
+	"testing"
+
+	"github.com/tonkeeper/tongo/boc"
+)
+
+// TestEmulatorAcceptsBuiltLeveledBoc feeds a cell tree built in memory around a pruned
+// branch to ton's own boc deserializer (through libemulator), which validates the level
+// mask every cell declares. A parent claiming level 0 over a level 1 child is rejected
+// there with "level mask mismatch".
+func TestEmulatorAcceptsBuiltLeveledBoc(t *testing.T) {
+	pruned := boc.NewCellExotic(boc.PrunedBranchCell)
+	if err := pruned.WriteUint(uint64(boc.PrunedBranchCell), 8); err != nil {
+		t.Fatalf("WriteUint() failed: %v", err)
+	}
+	if err := pruned.WriteUint(1, 8); err != nil { // level mask of the replaced cell
+		t.Fatalf("WriteUint() failed: %v", err)
+	}
+	if err := pruned.WriteBytes(make([]byte, 32)); err != nil { // hash of the replaced cell
+		t.Fatalf("WriteBytes() failed: %v", err)
+	}
+	if err := pruned.WriteUint(0, 16); err != nil { // depth of the replaced cell
+		t.Fatalf("WriteUint() failed: %v", err)
+	}
+	pruned.ResetCounters()
+
+	// an ordinary cell over a pruned branch: this is the one that used to claim level 0
+	virtualRoot := boc.NewCell()
+	if err := virtualRoot.AddRef(pruned); err != nil {
+		t.Fatalf("AddRef() failed: %v", err)
+	}
+	virtualRootHash, err := virtualRoot.HashAtLevel(0)
+	if err != nil {
+		t.Fatalf("HashAtLevel() failed: %v", err)
+	}
+
+	// a merkle proof root keeps the tree at level 0 overall, which is what the
+	// deserializer requires of a root cell.
+	root := boc.NewCellExotic(boc.MerkleProofCell)
+	if err := root.WriteUint(uint64(boc.MerkleProofCell), 8); err != nil {
+		t.Fatalf("WriteUint() failed: %v", err)
+	}
+	if err := root.WriteBytes(virtualRootHash[:]); err != nil {
+		t.Fatalf("WriteBytes() failed: %v", err)
+	}
+	if err := root.WriteUint(1, 16); err != nil { // depth of the virtual root
+		t.Fatalf("WriteUint() failed: %v", err)
+	}
+	if err := root.AddRef(virtualRoot); err != nil {
+		t.Fatalf("AddRef() failed: %v", err)
+	}
+	root.ResetCounters()
+
+	dataBoc, err := root.ToBocBase64()
+	if err != nil {
+		t.Fatalf("ToBocBase64() failed: %v", err)
+	}
+	codeBoc, err := boc.NewCell().ToBocBase64()
+	if err != nil {
+		t.Fatalf("ToBocBase64() failed: %v", err)
+	}
+	if _, err := NewEmulatorFromBOCsBase64(codeBoc, dataBoc, ""); err != nil {
+		t.Fatalf("ton refused the boc we produced: %v", err)
+	}
+
+	// the very same tree, but with the ordinary parent claiming level 0 over its
+	// level 1 child - byte for byte what tongo used to emit before level masks
+	// were derived. ton rejects it with "level mask mismatch".
+	const brokenBoc = "te6ccgEBAwEATwAJRgMRvBFcAiYynJo1p/7h0pwfUkjg94QdV4KbUCeCYxSREwABAQEAAihIAQEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	if brokenBoc == dataBoc {
+		t.Fatal("the broken boc must differ from what we emit now")
+	}
+	if _, err := NewEmulatorFromBOCsBase64(codeBoc, brokenBoc, ""); err == nil {
+		t.Error("ton accepted a boc with a level mask mismatch, the check is not doing anything")
+	}
+}


### PR DESCRIPTION
boc.Cell.mask was only ever populated by the deserializer (from the d1 byte) and hand-set once in pruneCells. Nothing else maintained it: NewCell leaves it at 0 and AddRef never ORs a child's mask into the parent, so any tree built in memory around a nonzero-level cell - everything tlb.Marshal produces, e.g. via txemulator.tlbStructToBase64 - serialized as a level 0 parent over a level 1 child. ton rejects that with "level mask mismatch". The same stale mask made newImmutableCell compute the wrong number of hashes, so Hash256() of a freshly built tree disagreed with the identical wire-decoded one.

Drop the field and derive the mask from a cell's type, content and refs the way ton's DataCell::create does: ordinary is the union of its refs, pruned branch takes its mask from the data, library is 0, and merkle cells shift right - a plain union would give a merkle proof root the wrong level. Both consumers go through the one rule, so serialization and hashing can no longer drift apart.

Deriving a pruned branch's mask also validates its body length, which closes an out of range read in immutableCell.Hash/Depth reachable from any boc.

Hash256() keeps returning the hash of the highest level, matching ton's Cell::get_hash(). For a tree with pruned branches that is no longer the representation hash, so HashAtLevel is added to get it.